### PR TITLE
Changed the linking for RegistrationDate and made it pull from Strapi

### DIFF
--- a/client/src/pages/upcomingElections/electionCard.tsx
+++ b/client/src/pages/upcomingElections/electionCard.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 type Props = {
     electionName: string;
     electionDate: Date;
+    registrationDate: Date;
 };
 
 const formatDate = (dateString: string): string => {
@@ -35,7 +36,7 @@ const daysLeft = (date: Date): number | null => {
     return days >= 0 ? days : null; // Return null if the date has already passed
 };
 
-export default function ElectionCard({ electionName = 'Preliminary Municipal Election', electionDate }: Props) {
+export default function ElectionCard({ electionName = 'Preliminary Municipal Election', electionDate, registrationDate }: Props) {
     const [displayElectionDate, setDisplayElectionDate] = useState('');
     const [displayRegistrationDate, setDisplayRegistrationDate] = useState('');
     const [daysRemaining, setDaysRemaining] = useState<number | null>(null);
@@ -50,35 +51,36 @@ export default function ElectionCard({ electionName = 'Preliminary Municipal Ele
 
     useEffect(() => {
         if (electionDate) {
-            // Create a new Date object and set the time to midnight local time
+            // Create a new Date object and set the time to midnight UTC
             const electionDateObj = new Date(electionDate);
-            electionDateObj.setHours(0, 0, 0, 0);
+            electionDateObj.setUTCHours(0, 0, 0, 0);
 
             const formattedElectionDate = electionDateObj.toLocaleDateString('en-US', {
                 month: 'long',
                 day: 'numeric',
                 year: 'numeric',
+                timeZone: 'UTC'
             });
 
             setDisplayElectionDate(formattedElectionDate);
 
-            // Calculate the registration date and set the time to midnight local time
-            const registrationDate = new Date(electionDateObj);
-            registrationDate.setDate(registrationDate.getDate() - 10);
-            registrationDate.setHours(0, 0, 0, 0);
+            // Create a new registration date and set the time to midnight UTC
+            const registrationDateObj = new Date(registrationDate);
+            registrationDateObj.setUTCHours(0, 0, 0, 0);
 
-            const formattedRegistrationDate = registrationDate.toLocaleDateString('en-US', {
+            const formattedRegistrationDate = registrationDateObj.toLocaleDateString('en-US', {
                 month: 'long',
                 day: 'numeric',
                 year: 'numeric',
+                timeZone: 'UTC'
             });
 
             setDisplayRegistrationDate(formattedRegistrationDate);
 
-            const calculatedDays = daysLeft(registrationDate);
+            const calculatedDays = daysLeft(registrationDateObj);
             setDaysRemaining(calculatedDays);
         }
-    }, [electionDate, electionName]);
+    }, [electionDate, registrationDate, electionName]);
 
     if (daysLeft(new Date(displayElectionDate)) == null) {
         return null;
@@ -115,9 +117,11 @@ export default function ElectionCard({ electionName = 'Preliminary Municipal Ele
                             <div className="text-blue-700 text-3xl font-medium leading-tight mb-4 mt-4">
                                 {electionName}
                             </div>
-                            <div className="text-gray-600 text-xl mb-4">
-                                <strong>Registration Deadline:</strong> {displayRegistrationDate} by 8PM
-                            </div>
+                            {displayRegistrationDate && (
+                                <div className="text-gray-600 text-xl mb-4">
+                                    <strong>Registration Deadline:</strong> {displayRegistrationDate} by 8PM
+                                </div>
+                            )}
                         </div>
 
                         {/* Right Side: Buttons */}

--- a/client/src/pages/upcomingElections/electionCard.tsx
+++ b/client/src/pages/upcomingElections/electionCard.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 type Props = {
     electionName: string;
     electionDate: Date;
-    registrationDate: Date;
+    registrationDate?: Date;
 };
 
 const formatDate = (dateString: string): string => {

--- a/client/src/pages/upcomingElections/electionDates.tsx
+++ b/client/src/pages/upcomingElections/electionDates.tsx
@@ -8,6 +8,7 @@ interface ElectionDateObject {
     attributes: {
         ElectionDate: Date;
         ElectionName: string;
+        RegistrationDate?: Date;
     }
 }
 
@@ -31,7 +32,15 @@ export default function ElectionDates() {
 
                 if (response.ok) {
                     const electionData = await response.json();
-                    setElectionDates(electionData.data)
+                    const processedData = electionData.data.map((item: any) => ({
+                        ...item,
+                        attributes: {
+                            ...item.attributes,
+                            ElectionDate: new Date(item.attributes.ElectionDate),
+                            RegistrationDate: item.attributes.RegistrationDate ? new Date(item.attributes.RegistrationDate) : undefined
+                        }
+                    }));
+                    setElectionDates(processedData);
                     setIsLoading(false);
 
                 } else {
@@ -69,7 +78,12 @@ export default function ElectionDates() {
                         <div className="flex items-center justify-center flex-wrap">
                            
                             {sortedElectionDates.map((election, index) => (
-                                <ElectionCard key={index} electionName={election.attributes.ElectionName} electionDate={election.attributes.ElectionDate} />
+                                <ElectionCard 
+                                    key={index}
+                                    electionName={election.attributes.ElectionName} 
+                                    electionDate={election.attributes.ElectionDate} 
+                                    registrationDate={election.attributes.RegistrationDate} 
+                                />
                             ))}
                         </div>
                     )}

--- a/strapi/src/api/boston-municipal-election-date/content-types/boston-municipal-election-date/schema.json
+++ b/strapi/src/api/boston-municipal-election-date/content-types/boston-municipal-election-date/schema.json
@@ -17,6 +17,9 @@
     },
     "ElectionDate": {
       "type": "date"
+    },
+    "RegistrationDate": {
+      "type": "date"
     }
   }
 }


### PR DESCRIPTION
Instead of manually calculating the registration deadline for each event, it now pulls directly from the input field in Strapi. Also changed a timing issue where the timezones in vscode did not link up to the timezone (UTC) set by strapi so the days displayed on website were a day behind.